### PR TITLE
Cross-season crops + "current day" input

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Number of days | Designates the number of days to be used in the calculation. Th
 Produce type | Designates the type of produce to be sold after harvesting. By default, all crops are harvested and sold as raw. This option accounts for Normal/Silver/Gold ratios, *Farming* skill level, and some additional skills. Other options let you select the two different artisan goods.
 Number of crops | This controls the number of crops that the player has planted.
 Average profits | Checking this, only average profits per day will be calculated. The average is calculated through the number of days set earlier.
+Cross season | If this is checked, the calculations will take into account the crops that don't die when there's a season change.
 Seed sources | Seeds can be obtained at different locations and different locations always have different costs too. This option lets you check which sources the graph should be looking for. Note that the cheapest option will always be shown on the graph. Unselecting certain locations might hide no longer obtainable crops.
 Pay for seeds | Selecting this means that the player is buying the seeds from one of the sources, instead of producing the seeds themselves (like using the *Seed Maker*). An orange bar will be shown for every crop, showing the seed loss if selected.
 Fertilizer | Different fertilizers can either speed up growth or increase the Normal/Silver/Gold ratios. The type of fertilizer can be selected here.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Option | Description
 --- | ---
 Season | Changes the season of the crops. This will affect list of the crops shown in the graph, as only some crops grow at certain seasons. Additionally, all seasons have a limit of 28 maximum days for calculation. The *Greenhouse* season doesn't have such limitations, shows all crops and allows for a duration of up to 100 thousand days.
 Number of days | Designates the number of days to be used in the calculation. The shorter the duration, the less crops will have time to grow. Some crops might not have time to grow even once if a too low value is set.
+Current day | The current date within the selected season. This is almost the same as "Number of days", but instead of specifying how many days are left, as a convenience you can just input the current in-game date.
 Produce type | Designates the type of produce to be sold after harvesting. By default, all crops are harvested and sold as raw. This option accounts for Normal/Silver/Gold ratios, *Farming* skill level, and some additional skills. Other options let you select the two different artisan goods.
 Number of crops | This controls the number of crops that the player has planted.
 Average profits | Checking this, only average profits per day will be calculated. The average is calculated through the number of days set earlier.

--- a/index.html
+++ b/index.html
@@ -61,6 +61,11 @@
 				<td><input type="checkbox" id="check_average" onChange="refresh()" /></td>
 			</tr>
 
+			<tr id="cross_season_row">
+				<td>Cross season:</td>
+				<td><input type="checkbox" id="cross_season" onChange="refresh()" /></td>
+			</tr>
+
 		</table>
 
 		<table cellspacing="2">

--- a/index.html
+++ b/index.html
@@ -35,7 +35,12 @@
 				</td>
 			</tr>
 
-			<tr>
+			<tr id="current_day_row">
+				<td>Current day:</td>
+				<td><input type="number" id="current_day" value="1" onChange="refresh()"/></td>
+			</tr>
+
+			<tr id="number_days_row">
 				<td>Number of days:</td>
 				<td><input type="number" id="number_days" value="28" onChange="refresh()"/></td>
 			</tr>

--- a/js/data.js
+++ b/js/data.js
@@ -141,7 +141,8 @@ var seasons = [
 			crops.garlic,
 			crops.parsnip,
 			crops.bluejazz,
-			crops.tulip
+			crops.tulip,
+			crops.ancientfruit
 		]
 	},
 	{
@@ -159,7 +160,10 @@ var seasons = [
 			crops.summerspangle,
 			crops.poppy,
 			crops.wheat,
-			crops.corn
+			crops.corn,
+			crops.coffeebean,
+			crops.sunflower,
+			crops.ancientfruit
 		]
 	},
 	{
@@ -179,7 +183,8 @@ var seasons = [
 			crops.bokchoy,
 			crops.sunflower,
 			crops.wheat,
-			crops.corn
+			crops.corn,
+			crops.ancientfruit
 		]
 	},
 	{

--- a/js/main.js
+++ b/js/main.js
@@ -912,13 +912,25 @@ function updateData() {
 
 	options.season = parseInt(document.getElementById('select_season').value);
 
-	if (document.getElementById('number_days').value <= 0)
-		document.getElementById('number_days').value = 1;
-	if (document.getElementById('number_days').value > 28 && options.season != 3)
-		document.getElementById('number_days').value = 28;
-	else if (document.getElementById('number_days').value > 100000 && options.season == 3)
-		document.getElementById('number_days').value = 100000;
-	options.days = document.getElementById('number_days').value;
+	if (options.season != 3) {
+		document.getElementById('current_day_row').style.display = 'table-row';
+		document.getElementById('number_days_row').style.display = 'none';
+		document.getElementById('cross_season_row').style.display = 'table-row';
+
+		if (document.getElementById('current_day').value <= 0)
+			document.getElementById('current_day').value = 1;
+		if (document.getElementById('current_day').value > 28 && options.season != 3)
+			document.getElementById('current_day').value = 28;
+		options.days = 28 - document.getElementById('current_day').value;
+	} else {
+		document.getElementById('current_day_row').style.display = 'none';
+		document.getElementById('number_days_row').style.display = 'table-row';
+		document.getElementById('cross_season_row').style.display = 'none';
+
+		if (document.getElementById('number_days').value > 100000 && options.season == 3)
+			document.getElementById('number_days').value = 100000;
+		options.days = document.getElementById('number_days').value;
+	}
 
 	options.produce = parseInt(document.getElementById('select_produce').value);
 

--- a/js/main.js
+++ b/js/main.js
@@ -79,6 +79,20 @@ function harvests(cropID) {
 	var crop = seasons[options.season].crops[cropID];
 	var fertilizer = fertilizers[options.fertilizer];
 
+	// if the crop is cross season, add 28 extra days for each extra season
+	var remainingDays = options.days;
+	if (options.crossSeason && options.season < 2) {
+		for (var i = options.season + 1; i < 3; i++) {
+			for (var j = 0; j < seasons[i].crops.length; j++) {
+				var seasonCrop = seasons[i].crops[j];
+				if (crop.name == seasonCrop.name) {
+					remainingDays += 28;
+					break;
+				}
+			}
+		}
+	}
+
 	// console.log("=== " + crop.name + " ===");
 
 	var harvests = 0;
@@ -89,10 +103,10 @@ function harvests(cropID) {
 	else
 		day += Math.floor(crop.growth.initial * fertilizer.growth);
 
-	if (day <= options.days)
+	if (day <= remainingDays)
 		harvests++;
 
-	while (day <= options.days) {
+	while (day <= remainingDays) {
 		if (crop.growth.regrow > 0) {
 			// console.log("Harvest on day: " + day);
 			day += crop.growth.regrow;
@@ -102,7 +116,7 @@ function harvests(cropID) {
 			day += Math.floor(crop.growth.initial * fertilizer.growth);
 		}
 
-		if (day <= options.days)
+		if (day <= remainingDays)
 			harvests++;
 	} 
 
@@ -913,6 +927,8 @@ function updateData() {
 	options.planted = document.getElementById('number_planted').value;
 
 	options.average = document.getElementById('check_average').checked;
+
+	options.crossSeason = document.getElementById('cross_season').checked;
 
 	options.seeds.pierre = document.getElementById('check_seedsPierre').checked;
 	options.seeds.joja = document.getElementById('check_seedsJoja').checked;

--- a/style/style.css
+++ b/style/style.css
@@ -48,7 +48,7 @@ body {
 	border-radius: 8px;
 	padding: 8px;
 	width: 768px;
-	height: 168px;
+	height: 174px;
     -webkit-filter: drop-shadow(0px 2px 8px rgba(0,0,0,0.75));
     -ms-filter: "progid:DXImageTransform.Microsoft.Dropshadow(OffX=0, OffY=2, Color='#000')";
     filter: "progid:DXImageTransform.Microsoft.Dropshadow(OffX=0, OffY=2, Color='#000')";


### PR DESCRIPTION
### Add "cross season" option
There are several crops that don't die when there's a change of season.

This enhancement makes it possible to calculate harvest prices taking cross season crops into account by selecting a checkbox.

### Allow user to input the current season day
This is just a convenience so the user doesn't have to manually subtract the crop growth time from the season length.

If the selected season is "Greenhouse", the regular "number of days" input will be shown instead.

Closes #3