### PR TITLE
Add fertilizers from the 1.5 update

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,8 +102,10 @@
 						<option value="0" selected="true">None</option>
 						<option value="1">Basic Fertilizer</option>
 						<option value="2">Quality Fertilizer</option>
+						<option value="5">Deluxe Fertilizer</option>
 						<option value="3">Speed-Gro</option>
 						<option value="4">Deluxe Speed-Gro</option>
+						<option value="6">Hyper Speed-Gro</option>
 					</select>
 				</td>
 			</tr>

--- a/js/data.js
+++ b/js/data.js
@@ -197,6 +197,63 @@ var ratios = {
 			"ratioS": 0.29,
 			"ratioG": 0.61
 		}
+	],
+	"deluxe": [
+		{
+			"ratioN": 0.69,
+			"ratioS": 0.2,
+			"ratioG": 0.11
+		},
+		{
+			"ratioN": 0.52,
+			"ratioS": 0.3,
+			"ratioG": 0.18
+		},
+		{
+			"ratioN": 0.38,
+			"ratioS": 0.37,
+			"ratioG": 0.25
+		},
+		{
+			"ratioN": 0.24,
+			"ratioS": 0.44,
+			"ratioG": 0.32
+		},
+		{
+			"ratioN": 0.15,
+			"ratioS": 0.46,
+			"ratioG": 0.39
+		},
+		{
+			"ratioN": 0.14,
+			"ratioS": 0.4,
+			"ratioG": 0.46
+		},
+		{
+			"ratioN": 0.12,
+			"ratioS": 0.35,
+			"ratioG": 0.53
+		},
+		{
+			"ratioN": 0.1,
+			"ratioS": 0.3,
+			"ratioG": 0.6
+		},
+		{
+			"ratioN": 0.08,
+			"ratioS": 0.25,
+			"ratioG": 0.67
+		},
+		{
+			"ratioN": 0.07,
+			"ratioS": 0.19,
+			"ratioG": 0.74
+		},
+		{
+			"ratioN": 0.05,
+			"ratioS": 0.14,
+			"ratioG": 0.81
+		}
 	]
 };
 
@@ -232,6 +289,18 @@ var fertilizers = [
 		"growth": 0.75,
 		"cost": 150,
 		"alternate_cost": 80
+	},
+	{
+		"name": "Deluxe Fertilizer",
+		"ratio": "deluxe",
+		"growth": 1,
+		"cost": 0
+	},
+	{
+		"name": "Hyper Speed-Gro",
+		"ratio": "none",
+		"growth": 0.67,
+		"cost": 0
 	}
 ];
 

--- a/js/main.js
+++ b/js/main.js
@@ -1109,7 +1109,7 @@ function optionsLoad() {
 	options.buySeed = validBoolean(options.buySeed);
 	document.getElementById('check_buySeed').checked = options.buySeed;
 
-	options.fertilizer = validIntRange(0, 4, options.fertilizer);
+	options.fertilizer = validIntRange(0, 6, options.fertilizer);
 	document.getElementById('select_fertilizer').value = options.fertilizer;
 
     options.fertilizerSource = validIntRange(0, 1, options.fertilizerSource);


### PR DESCRIPTION
Some design decisions were made:
- Kept previous positions in the array for backward compatibility with URLs
- Did not specify a cost for these fertilizers (they can only be crafted as far as I know)

Also, I used the quality ratios specified in [the wiki](https://stardewvalleywiki.com/Fertilizer#Soil_with_Deluxe_Fertilizer), which notes: "these are theoretical crop quality frequencies based on the formula described in Farming under _the assumption_ that Deluxe Fertilizer would be assigned a fertilizer quality value q of 3".