### PR TITLE
Fix fertilizer loss calculation

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -325,7 +325,7 @@ function fertLoss(crop) {
 		loss = -fertilizers[options.fertilizer].alternate_cost;
 	else
 		loss = -fertilizers[options.fertilizer].cost;
-	return loss * options.planted;
+	return loss * planted(crop);
 }
 
 /*


### PR DESCRIPTION
# Fixes Issue: #45 

This PR uses the _actual_ planted crops rather than the _maximum_ planted crops.

### Before:

![Screenshot 2022-10-07 at 16 52 25](https://user-images.githubusercontent.com/49308627/194595923-f947f75a-c8d0-4dbf-bd53-9c1d8a049919.png)

### After:

![Screenshot 2022-10-07 at 16 51 12](https://user-images.githubusercontent.com/49308627/194595983-2b75a9d2-a9e4-4473-ac87-f5cf8ec8b30f.png)
