### PR TITLE
Default farming and foraging to level 1

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1091,8 +1091,8 @@ function updateData() {
 	
 	options.fertilizerSource = parseInt(document.getElementById('speed_gro_source').value);
 
-	if (document.getElementById('farming_level').value < 0)
-		document.getElementById('farming_level').value = 0;
+	if (document.getElementById('farming_level').value <= 0)
+		document.getElementById('farming_level').value = 1;
 	if (document.getElementById('farming_level').value > 13)
 		document.getElementById('farming_level').value = 13;
 	options.level = parseInt(document.getElementById('farming_level').value);
@@ -1130,8 +1130,8 @@ function updateData() {
 		options.skills.arti = false;
 	}
 
-    if (document.getElementById('foraging_level').value < 0)
-        document.getElementById('foraging_level').value = 0;
+    if (document.getElementById('foraging_level').value <= 0)
+        document.getElementById('foraging_level').value = 1;
     if (document.getElementById('foraging_level').value > 13)
         document.getElementById('foraging_level').value = 13;
     options.foragingLevel = parseInt(document.getElementById('foraging_level').value);


### PR DESCRIPTION
### Bug Fix

Farming and foraging start at level 1 anyway so there's no need to start at level 0. Also there's currently weird behaviour when the values in those fields are _empty_, which this PR fixes.

![Screenshot 2022-10-07 at 16 56 26](https://user-images.githubusercontent.com/49308627/194596703-1d948f37-70d7-48ae-a0b2-603567ac97f5.png)