### PR TITLE
more accurate chance of extra potatoes

### DIFF
--- a/js/crops.js
+++ b/js/crops.js
@@ -377,7 +377,7 @@ var crops = {
     },
     "produce": {
       "extra": 1,
-      "extraPerc": 0.2,
+      "extraPerc": 0.25, // technically (0.2^1) + (0.2^2) + (0.2^3) ...
       "price": 80,
       "jarType": "Pickles",
       "kegType": "Juice"


### PR DESCRIPTION
TLDR: [crops.js line 380](https://github.com/Thorinair/Stardew-Profits/blob/ce9e633be12796d14e02fe0bf3694c9e5dd2a6ed/js/crops.js#L380) should be set to 0.25 instead of 0.2.

### Explanation

The Wiki page notes that [the actual potato calculation](https://stardewvalleywiki.com/Potato#cite_note-extraluck-1) is done iteratively _starting_ with 0.2, but not _ending_ there. The actual calculation is 20% for 1, and if successful, 20% (of 20%) for another, and so on. But if charted, you'll notice that the number approaches 25% with each increase in precision. 

| equation | result |
|--------|--------|
| 0.2 | 0.2 |
| 0.2 + (0.2^2) | 0.24 |
| 0.2 + (0.2^2) + (0.2^3) | 0.248 |
| 0.2 + (0.2^2) + (0.2^3) + (0.2^4) | 0.2496 | 