### PR TITLE
Dehydrator by Harvest Option

### DIFF
--- a/help.html
+++ b/help.html
@@ -54,7 +54,7 @@
                     </tr>
 					<tr>
 						<td>Produce Type</td>
-						<td>Designates the type of produce to be sold after harvesting. By default, all crops are harvested and sold as raw. This option accounts for Normal/Silver/Gold ratios, <em>Farming</em> skill level, and some additional skills. Other options let you select one of the three different artisan goods. *Please take note that the Dehydrator may not use all produced crops, or not have enough crops to create dried goods. *Please take note that the Dehydrator may not use all produced crops, or not have enough crops to create dried goods. See "Sell Excess" for unused produce.</td>
+						<td>Designates the type of produce to be sold after harvesting. By default, all crops are harvested and sold as raw. This option accounts for Normal/Silver/Gold ratios, <em>Farming</em> skill level, and some additional skills. Other options let you select one of the three different artisan goods. See "Dehydrator Excess" for unused produce.</td>
 					</tr>
                     <tr>
                         <td>Equipment</td>
@@ -67,6 +67,10 @@
                     <tr>
                         <td>Dehydrator Excess</td>
                         <td>If there is unused produce from the Dehydrator type product, the excess produce will be sold at normal value and added to the profit.</td>
+                    </tr>
+                    <tr>
+                        <td>Dehydrator By Harvest</td>
+                        <td>Dried goods will only be created that can be per harvest. If there are excess crops unused, they will not be crafted into a dry good. Deselecting this will accumulate unused excess per harvest to see if a dried good can be created.</td>
                     </tr>
                     <tr>
                         <td>Aging</td>

--- a/index.html
+++ b/index.html
@@ -72,19 +72,23 @@
             <tr>
                 <td colspan="2" class="sub">
                     <table cellspacing="2" class="subt">
-                        <tr>
+                        <tr id="equipment">
                             <td>Equipment:</td>
                             <td><input type="number" id="equipment" value="0" onChange="refresh()"/></td>
                         </tr>
-                        <tr>
+                        <tr id="noArtisanGood">
                             <td>No Artisan Good:</td>
                             <td><input type="checkbox" id="check_sellRaw" onChange="refresh()"/> Sell Raw<br /></td>
                         </tr>
-                        <tr>
-                            <td>Dehydrator Excess:</td>
+                        <tr id="excess">
+                            <td>Excess:</td>
                             <td><input type="checkbox" id="check_sellExcess" onChange="refresh()"/> Sell Raw<br /></td>
                         </tr>
-                        <tr>
+                        <tr id="byHarvest">
+                            <td>By Harvest:</td>
+                            <td><input type="checkbox" id="check_byHarvest" onChange="refresh()"/><br /></td>
+                        </tr>
+                        <tr id="aging">
                             <td>Aging:</td>
                             <td >
                                 <select id="select_aging" onChange="refresh()">

--- a/style/style.css
+++ b/style/style.css
@@ -84,6 +84,10 @@ body {
     margin: 0px;
 }
 
+.hidden {
+	display: none;
+}
+
 #tdhelp {
 	background-color: transparent;
 }


### PR DESCRIPTION
Updates:

- Add option "By Harvest" for produce type Dehydrator
    - This allows user to set Dried Goods to only be created by harvest. If there are not enough produce to create a dried good then no items will be created. It also accounts for replant/reuse.
- UI Updates Under Produce Type:
    - Sets additional options by produce to show/Hide accordingly, IE: If produce type Jar is selected all relevant options are shown: Equipment, No Artisan Good and non relevant are hidden: Aging, Excess, By Harvest
    - Want to test this look and feel as this area is getting a bit clustered as more options are being created due to Dehydrator additions.