### PR TITLE
Add support for crop links opening in new tab using middle mouse click

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1461,6 +1461,20 @@ function renderGraph() {
 				tooltip.style("top", (d3.event.pageY - 16) + "px").style("left",(d3.event.pageX + 20) + "px");
 			})
 			.on("mouseout", function() { tooltip.style("visibility", "hidden"); })
+			.on("auxclick", function(d) { 
+				if (options.disableLinks) {
+					return;
+				}
+
+				// Only opens a new wiki tab if it's the middle
+				// mouse button that was pressed.
+				// See <https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button#value>
+				if (d3.event.button !== 1) {
+					return;
+				}
+
+				window.open(d.url, "_blank"); 
+			})
 			.on("click", function(d) { 
 				if(!options.disableLinks)
 					window.open(d.url, "_blank"); 


### PR DESCRIPTION
This tiny PR adds support for middle mouse click opening the crop wiki link in a new tab just like a left-click. 

(This is also how most browsers handle native <a> links, which is why this — while being a tiny thing — has tripped me up before and so here I am with a tiny PR.)

How? Previously, only the `click` DOM event was handled. Now we also handle the `auxclick` event and filter it to `event.button === 1`, meaning we now also open the crop wiki page when the middle mouse button is pressed on the crop bar in the graph.

Thanks for the great tool!